### PR TITLE
Revert "Use data criteria field values to export QRDA elements in CAT1"

### DIFF
--- a/lib/health-data-standards/export/helper/cat1_view_helper.rb
+++ b/lib/health-data-standards/export/helper/cat1_view_helper.rb
@@ -26,7 +26,7 @@ module HealthDataStandards
           data_criteria_html = udcs.map do |udc|
             # If there's an error exporting particular criteria, re-raise an error that includes useful debugging info
             begin
-              entries = entries_for_data_criteria(udc['data_criteria'], patient, udc)
+              entries = entries_for_data_criteria(udc['data_criteria'], patient)
               render_data_criteria(udc, entries, r2_compatibility, qrda_version)
             rescue => e
               raise HealthDataStandards::Export::PatientExportDataCriteriaException.new(e.message, patient, udc['data_criteria'], entries)

--- a/lib/health-data-standards/export/helper/scooped_view_helper.rb
+++ b/lib/health-data-standards/export/helper/scooped_view_helper.rb
@@ -93,7 +93,7 @@ module HealthDataStandards
         end
 
         # Find all of the entries on a patient that match the given data criteria
-        def entries_for_data_criteria(data_criteria, patient, udc=nil)
+        def entries_for_data_criteria(data_criteria, patient)
 
           data_criteria_oid = HQMFTemplateHelper.template_id_by_definition_and_status(data_criteria.definition,
                                                                                       data_criteria.status || '',
@@ -163,8 +163,6 @@ module HealthDataStandards
                   ttc = entry.transferTo.codes_in_code_set(codes).values.first
                   ttc && !ttc.empty?
                 end
-              elsif data_criteria.field_values && udc
-                  entry.is_in_code_set?(codes) && (is_hqmfr2 || !!entry.negation_ind == data_criteria.negation) && is_field_values_in_entry(udc['field_oids'], entry)
               else
                 # The !! hack makes sure that negation_ind is a boolean. negations use the same hqmf templates in r2
                 entry.is_in_code_set?(codes) && (is_hqmfr2 || !!entry.negation_ind == data_criteria.negation)
@@ -196,22 +194,6 @@ module HealthDataStandards
         def handle_payer_information(patient)
           patient.insurance_providers
         end
-
-        def is_field_values_in_entry(field_values, entry)
-          field_values.each do |field, values|
-            values.uniq.each { |code_list_id|
-            codes = (value_set_map(patient["bundle_id"])[code_list_id] || [])
-              if codes.empty?
-                HealthDataStandards.logger.warn("No codes for FieldValue #{code_list_id}")
-              end
-              if entry.is_field_value_codes_in_code_set?(field, codes)
-                return true
-              end
-            }
-          end
-          false
-        end
-
       end
     end
   end

--- a/lib/health-data-standards/models/entry.rb
+++ b/lib/health-data-standards/models/entry.rb
@@ -129,32 +129,6 @@ class Entry
     false
   end
 
-  def is_input_codes_in_code_set?(input_codes, code_set)
-    input_codes.keys.each do |code_system|
-      all_codes_in_system = code_set.find_all {|set| set['set'] == code_system}
-      all_codes_in_system.each do |codes_in_system|
-        matching_codes = codes_in_system['values'] & input_codes[code_system]
-        if matching_codes.length > 0
-          return true
-        end
-      end
-    end
-    false
-  end
-
-  def is_field_value_codes_in_code_set?(field, code_set)
-    codes = {}
-    case field
-    when "DISCHARGE_STATUS"
-      codes = {dischargeDisposition['codeSystem'] => Array.new(1, dischargeDisposition['code'])} if dischargeDisposition
-    when "PRINCIPAL_DIAGNOSIS"
-      codes = principalDiagnosis['codes'] if principalDiagnosis
-    else
-      return true
-    end
-    return is_input_codes_in_code_set?(codes, code_set)
-  end
-
   # Tries to find a single point in time for this entry. Will first return time if it is present,
   # then fall back to start_time and finally end_time
   def as_point_in_time

--- a/templates/html/_entries_by_section.html.erb
+++ b/templates/html/_entries_by_section.html.erb
@@ -5,7 +5,7 @@
     udcs_entries = nil
     if measures.length > 0
       udcs = unique_data_criteria(measures, false) 
-      udcs_entries = udcs.collect{|dc|  entries_for_data_criteria(dc['data_criteria'],patient, dc)}
+      udcs_entries = udcs.collect{|dc|  entries_for_data_criteria(dc['data_criteria'],patient)}
       udcs_entries.flatten!
       udcs_entries.uniq!
     end


### PR DESCRIPTION
Reverts OSEHRA/health-data-standards#20 due to missing ICU encounter entry in the exported CAT1 file from a Cypress test deck for measure CMS108