### PR TITLE
Fixed issue resolving reference_ID

### DIFF
--- a/lib/health-data-standards/models/reference.rb
+++ b/lib/health-data-standards/models/reference.rb
@@ -16,7 +16,7 @@ class Reference
   def resolve_referenced_id
     resolved_reference = entry.record.entries.find do |e|
       e.class.to_s == referenced_type &&
-      e.identifier == referenced_id
+      e.identifier.extension == referenced_id
     end
     self.referenced_id = resolved_reference.id.to_s
   end


### PR DESCRIPTION
I found a bug that occurs when the QRDA cat 1, contains two communication from provider to provider elements, each one referencing to different referral interventions. 

If you upload a QRDA cat 1 with only one communication from provider to provider, the error never happens.

You can see the error happening in action if you upload the attached sample 
[Sample.zip](https://github.com/OSEHRA/health-data-standards/files/3658603/Sample.zip)

When you make the proposed fix, the error disappears.

Thank you 
