### PR TITLE
pophealth QRDA cat 1 throws and exception when repeatnumber is present

### DIFF
--- a/lib/health-data-standards/import/cda/medication_importer.rb
+++ b/lib/health-data-standards/import/cda/medication_importer.rb
@@ -39,7 +39,7 @@ module HealthDataStandards
           medication.indication = extract_code(entry_element, @indication_xpath, 'SNOMED-CT')
           medication.vehicle = extract_code(entry_element, @vehicle_xpath, 'SNOMED-CT')
 
-          medication.allowed_administrations = extract_scalar(entry_element, "./cda:repeatNumber").value unless extract_scalar(entry_element, "./cda:repeatNumber").nil?
+          medication.allowed_administrations = extract_scalar(entry_element, "./cda:repeatNumber")['value'] unless extract_scalar(entry_element, "./cda:repeatNumber").nil?
 
           extract_order_information(entry_element, medication)
 


### PR DESCRIPTION
When uploading a QRDA cat 1 with a substance of administration that contains repeatNumber with a value. Pophealth is throwing an exception.  Now it works after the change I made